### PR TITLE
fix: change cursor style from default to inherit when spoiler is revealed

### DIFF
--- a/packages/components/src/components/spoiler-span/spoiler-span.css
+++ b/packages/components/src/components/spoiler-span/spoiler-span.css
@@ -22,7 +22,7 @@ div.revealing {
 
 div.revealed {
   color: inherit;
-  cursor: default;
+  cursor: inherit;
   user-select: text;
 }
 


### PR DESCRIPTION
This PR updates the cursor style in the `.revealed` class from `cursor: default` to `cursor: inherit`, allowing parent elements to control cursor behavior on revealed spoilers.